### PR TITLE
makes getting the application name pluggable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Auth toolbox acts as a Policy Enforcement Point (PEP).
 
 All the permissions received from the PDP (Policy Decision Point) will be added to the claims of the User's principal and are available in the application.
 
-The toolbox also provides Authorization attributes that can be used in the controllers to enforce authorization.  
+The toolbox also provides Authorization attributes that can be used in the controllers to enforce authorization.
 
 
 ## Table of Contents
@@ -73,11 +73,11 @@ To add the toolbox to a project, you add the package to the csproj project file:
   <ItemGroup>
     <PackageReference Include="Digipolis.Auth" Version="3.0.0" />
   </ItemGroup>
-``` 
+```
 
 or if your project still works with project.json :
 
-``` json 
+``` json
 "dependencies": {
     "Digipolis.Auth":  "3.0.0"
  }
@@ -168,9 +168,9 @@ Option              | Description                                               
 ApplicationName              | The name of the application. Required in order to request permissions to the PDP.|
 PdpUrl | The url for the policy decision provider (PDP). |
 PdpApiKey | The api key for the PDP endpoint. |
-PdpCacheDuration | The duration in minutes the responses from the PDP are cached. Set to zero to disable caching.| 60 
-JwtIssuer | The issuer value used to validate the Jwt token.| 
-JwtAudience | The audience url used to validate the Jwt token.| 
+PdpCacheDuration | The duration in minutes the responses from the PDP are cached. Set to zero to disable caching.| 60
+JwtIssuer | The issuer value used to validate the Jwt token.|
+JwtAudience | The audience url used to validate the Jwt token.|
 JwtSigningKeyCacheDuration | The duration in minutes the Jwt signing key is cached.| 1440 (24 hours)
 TokenRefreshRoute | The route used for the token refresh endpoint.| "auth/token/refresh"
 PermissionsRoute | The route used for the permissions endpoint.| "auth/user/permissions"
@@ -180,15 +180,15 @@ Options used for JwtHeaderAuth
 
 Option              | Description                                                | Default
 ------------------ | ----------------------------------------------------------- | --------------------------------------
-EnableJwtHeaderAuth              | Set to true to enable the JwtHeaderAuth scheme. (Web Api)| True  
+EnableJwtHeaderAuth              | Set to true to enable the JwtHeaderAuth scheme. (Web Api)| True
 
 Options used for CookieAuth
 
 Option              | Description                                                | Default
 ------------------ | ----------------------------------------------------------- | --------------------------------------
-EnableCookieAuth              | Set to true to enable the CookieAuth scheme. (Web MVC)| False 
+EnableCookieAuth              | Set to true to enable the CookieAuth scheme. (Web MVC)| False
 ApplicationBaseUrl              | The base url for the application, including scheme and eventual port.|
-ApiAuthUrl | The url of the Api Engine authentication endpoint.| 
+ApiAuthUrl | The url of the Api Engine authentication endpoint.|
 ApiAuthIdpUrl | The url of the Idp the Api Engine will redirect the saml request to.|
 ApiAuthSpName | The service provider name of the Api Engine.|
 ApiAuthSpUrl | The Api Engine callback url where the idp must redirect to.|
@@ -197,9 +197,9 @@ ApiAuthTokenLogoutUrl | The Api Engine authentication logout url.|
 TokenCallbackRoute | The route used for the token callback url.| "auth/token"
 AutomaticTokenRefresh | Set to true to enable automatic token refresh.| false
 TokenRefreshTime | The amount of minutes before the jwt token expiration time at which to automatically refresh the token.| 5
-AccessDeniedPath | The path to redirect when the access is denied. | 
-UseDotnetKeystore | Set to true to use a shared (external) dataprotection key store to store the key used by cookie auth.| 
-DotnetKeystore | Connection string for the shared dataprotection key store.| 
+AccessDeniedPath | The path to redirect when the access is denied. |
+UseDotnetKeystore | Set to true to use a shared (external) dataprotection key store to store the key used by cookie auth.|
+DotnetKeystore | Connection string for the shared dataprotection key store.|
 AddJwtCookie | Set to true to add the jwt token in a cookie. | True
 AddJwtToSession | Set to true to add the jwt token to the Http Session. | False
 CookieAuthLifeTime | CookieAuth authentication ticket life time. | 480 (8 hours)
@@ -210,7 +210,7 @@ JwtTokenSource | Sets the source for the UserToken property in the AuthService. 
 
 An optional parameter of type **Dictionary&lt;string, AuthorizePolicy&gt;** is available on both **AddAuth** methods. With this parameter it is possible to add a collection of (Microsoft.AspNet) authorization policies.
 
-Note: These policies are not to be confused with the policies as defined in the Identity Server and used in the PEP / PDP concept. 
+Note: These policies are not to be confused with the policies as defined in the Identity Server and used in the PEP / PDP concept.
 
 
 ## Configuration in Startup.Configure
@@ -224,7 +224,7 @@ Please note that the order in which middleware is added is the order of executio
 
 ## Authorization usage
 
-To authorize users to access actions on controllers (resources) you can use two types of attributes: 
+To authorize users to access actions on controllers (resources) you can use two types of attributes:
 
  - AuthorizeByConvention
  - AuthorizeWith
@@ -330,7 +330,7 @@ Login and logout is only applicable to the CookieAuth scheme (Web MVC projects).
 
 ### Login
 
-Login is automatically handled when placing an Authorize attribute on a controller or action. If no authorization cookie is present on the request the auth toolbox will return a redirect to start the login procedure on the external identity provider. 
+Login is automatically handled when placing an Authorize attribute on a controller or action. If no authorization cookie is present on the request the auth toolbox will return a redirect to start the login procedure on the external identity provider.
 
 ### Logout
 
@@ -402,7 +402,7 @@ You can access the **User** object through the **AuthService**.
     {
         _authService = authService;
     }
-    
+
     public void SomeMethod()
     {
         //Access the User
@@ -410,7 +410,7 @@ You can access the **User** object through the **AuthService**.
     }
 ```
 
-To get the user's jwt token you can read the **UserToken** property.  
+To get the user's jwt token you can read the **UserToken** property.
 The token will only be set if session state is enabled and configured and if the **AddJwtToSession** property in the options is set to **True**.
 
 ``` csharp
@@ -420,14 +420,14 @@ The token will only be set if session state is enabled and configured and if the
 
 ### Jwt token in cookie
 
-When using the **CookieAuth** scheme the jwt token received after login can be added in a cookie witk key "jwt".  
-Using the **AddJwtCookie** setting in the options this can be turned on or off. By default it is turned on.  
+When using the **CookieAuth** scheme the jwt token received after login can be added in a cookie witk key "jwt".
+Using the **AddJwtCookie** setting in the options this can be turned on or off. By default it is turned on.
 If you don't want the jwt token to be sent to the front end (in a cookie) set the option to **false**.
 
 ### Jwt token in session
 
-When using the **CookieAuth** scheme the jwt token received after login can be added to the session.  
-Using the **AddJwtToSession** setting in the options this can be turned on or off. By default it is turned on.  
+When using the **CookieAuth** scheme the jwt token received after login can be added to the session.
+Using the **AddJwtToSession** setting in the options this can be turned on or off. By default it is turned on.
 Be sure to enable and configure session state when using this feature.
 
 You can extract the jwt token from the session using the key **"auth-jwt"**
@@ -439,9 +439,9 @@ You can extract the jwt token from the session using the key **"auth-jwt"**
 ### Development permissions
 
 In order to facilitate development you can use a feature called **Development permissions**. When the application runs in **Development** environment or in the environment specified by the **Environment** property of the **DevPermissionsOptions**, it is possible to bypass the PDP request and get the requested permissions from configuration.
-This way it is not needed to set up the permissions in the permissions' management infrastructure (IDP). 
+This way it is not needed to set up the permissions in the permissions' management infrastructure (IDP).
 
-In order to use the development permissions the config file must have a section **DevPermissions** with the **UseDevPermissions** property set to **true**. 
+In order to use the development permissions the config file must have a section **DevPermissions** with the **UseDevPermissions** property set to **true**.
 This will only work when the application is running in **Development** environment or in the environment specified by the **Environment** property of the **DevPermissionsOptions**
 
 In the **Development** environment the token lifetimevalidation can be disabled by setting  **ValidateTokenLifetime** to false. This enables easy testing without having to refresh the token.
@@ -463,8 +463,22 @@ In the **DevPermissions** section of the config file you can set the permissions
 ### Disabling Jwt signature validation for testing purposes
 
 In order to be able to run integration tests against your application it is possible to disable the signature validation for the used jwt token. This can be done by setting the **RequireSignedTokens** property of the **DevPermissionsOptions** to false.
-This allows you to use a dummy jwt token during your integration tests. 
+This allows you to use a dummy jwt token during your integration tests.
 The disabling of the signature validation will only work when the application is running in the environment specified by the **Environment** property of the **DevPermissionsOptions**.
+
+### Overriding the default application name for retrieving permissions
+
+By default, the **applicationname** used to fetch the user's permissions is retrieved from
+``` json
+{
+  "Auth": {
+    "ApplicationName": "TESTAPP",
+  }
+}
+```
+(in this case: `TESTAPP`).
+However it is possible to override this default behaviour for cases where the `ApplicationName` is not known upfront (e.g. dependent on the request).
+In that case, one needs to implement the `IPermissionApplicationNameProvider` interface and register the new service.
 
 ## How it works
 
@@ -477,10 +491,10 @@ The above picture visualizes the basic authentication and authorization flow.
 
 The first step is to authenticate the user (1).
 Depending on the enabled schemes this is done using a jwt token or a cookie.
-After authentication, the permissions for the user are set as claims on the user principal. This is done in a claims transformation step (2). 
-The permissions for the user are requested to a Policy Decision Point (2a) and can be cached. 
+After authentication, the permissions for the user are set as claims on the user principal. This is done in a claims transformation step (2).
+The permissions for the user are requested to a Policy Decision Point (2a) and can be cached.
 The final step is the authorization for the requested resource. In this step the required permissions for the resource are checked against the permissions from the user.
-If the user is not authorized to access the resource the request will return with an Http status code of 401 (UnAuthorized). 
+If the user is not authorized to access the resource the request will return with an Http status code of 401 (UnAuthorized).
 It is still possible to allow resources to anonymous users using the **AllowAnonymous** attribute.
 If the user is not authenticated it will result in an empty user principal containing no claims, thus authorization will fail for resources that requires permissions.
 
@@ -493,19 +507,19 @@ The above picture visualizes the request flow and the middleware's in action.
 1. Authentication middleware
     Handles authentication for the user, depending on selected schemes.
 	If the cookie is present and valid, the user is authenticated.
-    If the jwt token is presentand valid, the user is authenticated.  
+    If the jwt token is presentand valid, the user is authenticated.
 
-2. ClaimsTransformation middleware  
+2. ClaimsTransformation middleware
 	If a user is authenticated, the permissions of the user are added as claims on the User's identity.
 
 3. If an Authorize... attribute is present on a controller or action, the filter checks the required permission for the action.
 
-4. If the user doesn't have the required permission, the request pipeline is interrupted  
+4. If the user doesn't have the required permission, the request pipeline is interrupted
 	An http status code 403 is set on the response object.
 
-5. If the user has the requested permission, the action is invoked  
+5. If the user has the requested permission, the action is invoked
 
-6. Authentication middleware checks if a 401 or 403 status code is set on the response object  
+6. Authentication middleware checks if a 401 or 403 status code is set on the response object
 	If it is set and in combination of the authorization schema "CookieAuth" the response is transformed in a redirect response.
 
 ### CookieAuth scheme
@@ -518,7 +532,7 @@ The scheme relies on an authentication cookie to authenticate the user. If no co
 Once the token is received and validated, the user is signed in and two cookies are set. The first is an authentication cookie and is the default asp.net cookie. The second is a cookie containing the jwt token.
 This cookie named **jwt** can be used on the client side to extract the jwt token needed for Api calls (see jwtHeaderAuth flow).
 
-In order to be able to scale the application, the key used to encrypt the authentication cookie by the DataProtection api, can be stored in a shared database. The connection string to that database is set 
+In order to be able to scale the application, the key used to encrypt the authentication cookie by the DataProtection api, can be stored in a shared database. The connection string to that database is set
 in the **DotnetKeystore** property of the **AuthOptions**. To use this key from shared store the **UseDotnetKeystore** property on the **AuthOptions** must be set to true.
 
 ### JwtHeaderAuth scheme
@@ -527,19 +541,19 @@ The **JwtHeaderAuth** scheme can be used to secure your Web Api projects.
 
 All api controllers serving data can use this scheme.
 
-The scheme relies on a jwt token present in the authorization header. When a jwt token is present it is validated. 
+The scheme relies on a jwt token present in the authorization header. When a jwt token is present it is validated.
 If the user is not authenticated it will result in a response with http status code 401.
 If the user us authenticated but the authorization failed due to missing permissions it will result in a response with http status code 403.
 
 ### Jwt token
- 
+
  The toolbox uses a Jwt (JSON Web Token) to perform its authentication.
- For more details on how a Jwt is structured see https://jwt.io/introduction.  
- 
+ For more details on how a Jwt is structured see https://jwt.io/introduction.
+
 #### Structure
 
  Here is an example of a Jwt of an **authenticated user** (without signature) after base64 decoding:
- 
+
  ``` json
 {
   "alg": "RS256",
@@ -559,7 +573,7 @@ If the user us authenticated but the authorization failed due to missing permiss
 The toolbox supports two flavors of user token where the user id is present in the **sub** claim or **X-Authenticated-Userid** claim.
 
 In order to validate the token the toolbox performs these checks:
-  
+
  * Issuer validation
  * Token expiration
  * Signature validation
@@ -569,14 +583,14 @@ In order to validate the token the toolbox performs these checks:
 This checks if the token is originating from the expected issuer.
 The check compares the issuer value ("iss" claim) against a known value from toolbox configuration.
 If the values don't match the token is considered invalid.
-    
+
 #### Token expiration
 
 The value from the expiration claim ("exp") is compared against the current server time. If the value is expired the token is considered invalid.
 
 #### Signature validation
 
-In order to check the token origin and integrity, the token signature must be validated. 
+In order to check the token origin and integrity, the token signature must be validated.
 The signature from the token is considered to be RSA encrypted with an asymmetric public key.
 
 The signing key used to validate the signature will be acquired from the instance that issued the token.
@@ -586,7 +600,7 @@ The signing key can also be cached. The duration of the cache can be set using t
 
 #### Using serviceaccount permissions
 
-When using app-to-app communication without authentication of a user (e.g.event processing), the permissions are retrieved using the applicationname. 
+When using app-to-app communication without authentication of a user (e.g.event processing), the permissions are retrieved using the applicationname.
 The example below shows a JWT token without user authentication. The permissions are assigned to the serviceaccounts for **myapplicationname**.
 
  ``` json

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Auth Toolbox
 
+## 3.2.1
+- Made it possible to override the default behaviour of retrieving the ApplicationName
+
 ## 3.2.0
 - Update Digipolis.DataProtection.Postgres to 3.0.0 (.NET Standard 2.0 compatible)
 
@@ -28,7 +31,7 @@
 
 ## 2.2.0
 
-- Return http status codes instead of redirects when request is XMLHttpRequest or call to /api route with CookieAuth 
+- Return http status codes instead of redirects when request is XMLHttpRequest or call to /api route with CookieAuth
 
 ## 2.1.0
 

--- a/src/Digipolis.Auth/Digipolis.Auth.csproj
+++ b/src/Digipolis.Auth/Digipolis.Auth.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <VersionPrefix>3.2.0</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -9,7 +8,6 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.0.0" />
@@ -26,5 +24,4 @@
     <PackageReference Include="Digipolis.DataProtection.Postgres" Version="3.0.0" />
     <PackageReference Include="Digipolis.ApplicationServices" Version="2.0.0" />
   </ItemGroup>
-
 </Project>

--- a/src/Digipolis.Auth/Digipolis.Auth.csproj
+++ b/src/Digipolis.Auth/Digipolis.Auth.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.2.1</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Digipolis.Auth</AssemblyName>
     <PackageId>Digipolis.Auth</PackageId>

--- a/src/Digipolis.Auth/PDP/DefaultPermissionApplicationNameProvider.cs
+++ b/src/Digipolis.Auth/PDP/DefaultPermissionApplicationNameProvider.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Digipolis.Auth.Options;
+using Microsoft.Extensions.Options;
+
+namespace Digipolis.Auth.PDP
+{
+    public class DefaultPermissionApplicationNameProvider : IPermissionApplicationNameProvider
+    {
+        private readonly AuthOptions _authOptions;
+
+        public DefaultPermissionApplicationNameProvider(IOptions<AuthOptions> authOptions)
+        {
+            if( authOptions==null || authOptions.Value == null ) throw new ArgumentNullException(nameof(authOptions), $"{nameof(authOptions)} cannot be null");
+            _authOptions = authOptions.Value;
+        }
+        
+        public string ApplicationName()
+        {
+            return _authOptions.ApplicationName;
+        }
+    }
+}

--- a/src/Digipolis.Auth/PDP/IPermissionApplicationNameProvider.cs
+++ b/src/Digipolis.Auth/PDP/IPermissionApplicationNameProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace Digipolis.Auth.PDP
+{
+    public interface IPermissionApplicationNameProvider
+    {
+        string ApplicationName();
+    }
+}

--- a/src/Digipolis.Auth/PDP/PermissionsClaimsTransformer.cs
+++ b/src/Digipolis.Auth/PDP/PermissionsClaimsTransformer.cs
@@ -1,6 +1,4 @@
-﻿using Digipolis.Auth.Options;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.AspNetCore.Authentication;
 using System;
 using System.Linq;
 using System.Security.Claims;
@@ -10,15 +8,15 @@ namespace Digipolis.Auth.PDP
 {
     public class PermissionsClaimsTransformer : IClaimsTransformation
     {
-        private readonly AuthOptions _authOptions;
+        private readonly IPermissionApplicationNameProvider _permissionApplicationNameProvider;
         private readonly IPolicyDescisionProvider _pdpProvider;
 
-        public PermissionsClaimsTransformer(IOptions<AuthOptions> authOptions, IPolicyDescisionProvider pdpProvider)
+        public PermissionsClaimsTransformer(IPermissionApplicationNameProvider permissionApplicationNameProvider, IPolicyDescisionProvider pdpProvider)
         {
-            if (authOptions == null || authOptions.Value == null) throw new ArgumentNullException(nameof(authOptions), $"{nameof(authOptions)} cannot be null");
+            if(permissionApplicationNameProvider == null) throw new ArgumentNullException(nameof(permissionApplicationNameProvider), $"{nameof(permissionApplicationNameProvider)} cannot be null");
             if (pdpProvider == null) throw new ArgumentNullException(nameof(pdpProvider), $"{nameof(pdpProvider)} cannot be null");
 
-            _authOptions = authOptions.Value;
+            _permissionApplicationNameProvider = permissionApplicationNameProvider;
             _pdpProvider = pdpProvider;
         }
 
@@ -29,7 +27,7 @@ namespace Digipolis.Auth.PDP
 
             var userId = principal.Identity.Name;
 
-            var pdpResponse = await _pdpProvider.GetPermissionsAsync(userId, _authOptions.ApplicationName);
+            var pdpResponse = await _pdpProvider.GetPermissionsAsync(userId, _permissionApplicationNameProvider.ApplicationName());
 
             pdpResponse?.permissions?.ToList().ForEach(permission =>
             {

--- a/src/Digipolis.Auth/Startup/ServiceCollectionExtensions.cs
+++ b/src/Digipolis.Auth/Startup/ServiceCollectionExtensions.cs
@@ -193,6 +193,8 @@ namespace Digipolis.Auth
             {
                 services.AddSingleton<IPolicyDescisionProvider, PolicyDescisionProvider>();
             }
+
+            services.TryAddScoped<IPermissionApplicationNameProvider, DefaultPermissionApplicationNameProvider>();
         }
 
         private static T BuildOptions<T>(IServiceProvider serviceProvider, IServiceCollection services) where T : class, new()

--- a/test/Digipolis.Auth.UnitTests/Digipolis.Auth.UnitTests.csproj
+++ b/test/Digipolis.Auth.UnitTests/Digipolis.Auth.UnitTests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <Description>Unit tests for the Auth toolbox</Description>
     <Authors>digipolis.be</Authors>
@@ -7,11 +6,9 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Digipolis.Auth\Digipolis.Auth.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
@@ -20,11 +17,9 @@
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="Digipolis.ApplicationServices" Version="2.0.0" />
   </ItemGroup>
-
   <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta1-build3642" />    
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta1-build3642" />
   </ItemGroup>
-
   <!-- mark as test project -->
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
@@ -37,5 +32,4 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/test/Digipolis.Auth.UnitTests/PDP/DefaultPermissionApplicationNameProviderTest.cs
+++ b/test/Digipolis.Auth.UnitTests/PDP/DefaultPermissionApplicationNameProviderTest.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Digipolis.Auth.Options;
+using Digipolis.Auth.PDP;
+using Xunit;
+
+namespace Digipolis.Auth.UnitTests.PDP
+{
+    public class DefaultPermissionApplicationNameProviderTest
+    {
+        [Fact]
+        public void ThrowsExceptionIfOptionsIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DefaultPermissionApplicationNameProvider(null));
+        }
+        
+        [Fact]
+        public void ThrowsExceptionIfOptionsValueIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DefaultPermissionApplicationNameProvider(Options.Create<AuthOptions>(null)));
+        }
+
+        [Fact]
+        public void ApplicationNameReturnsTheApplicationNameFromAuthOptions()
+        {
+            var applicationName = "SOMECOOLAPP";
+            var authOptions = new AuthOptions()
+            {
+                ApplicationName = applicationName
+            };
+            var options = Options.Create(authOptions);
+            
+            var subject = new DefaultPermissionApplicationNameProvider(options);
+            
+            Assert.Equal(applicationName, subject.ApplicationName());
+        }
+    }
+}

--- a/test/Digipolis.Auth.UnitTests/Startup/DefaultPermissionApplicationNameProviderSetupTest.cs
+++ b/test/Digipolis.Auth.UnitTests/Startup/DefaultPermissionApplicationNameProviderSetupTest.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Linq;
+using Digipolis.ApplicationServices;
+using Digipolis.Auth.PDP;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Digipolis.Auth.UnitTests.Startup
+{
+    public class DefaultPermissionApplicationNameProviderSetupTest
+    {
+        [Fact]
+        public void ByDefaultTheDefaultPermissionApplicationNameProviderMustBeRegistered()
+        {
+            var applicationName = "ANOTHERCOOLAPP";
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddTransient<IApplicationContext>((serviceProvider) => { return Mock.Of<IApplicationContext>(); });
+            serviceCollection.AddTransient<IHostingEnvironment>((serviceProvider) => { return Mock.Of<IHostingEnvironment>(); });
+            serviceCollection.AddAuth(options =>
+            {
+                options.EnableCookieAuth = false;
+                options.UseDotnetKeystore = false;
+                options.EnableJwtHeaderAuth = false;
+                options.ApplicationName = applicationName;
+            });
+            
+            var registrations = serviceCollection.Where(sd => sd.ServiceType == typeof(IPermissionApplicationNameProvider) &&
+                                                     sd.ImplementationType == typeof(DefaultPermissionApplicationNameProvider))
+                .ToArray();
+
+            Assert.Single(registrations);
+            Assert.Equal(ServiceLifetime.Scoped, registrations[0].Lifetime);
+        }
+        
+        [Fact]
+        public void ItIsPossibleToOverrideTheIPermissionApplicationNameProviderImplementation()
+        {
+            var applicationName = "ANOTHERCOOLAPP";
+            var overridenApplicationName = "OVERRIDEN";
+            
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddTransient<IApplicationContext>((services) => { return Mock.Of<IApplicationContext>(); });
+            serviceCollection.AddTransient<IHostingEnvironment>((services) => { return Mock.Of<IHostingEnvironment>(); });
+            serviceCollection.AddAuth(options =>
+            {
+                options.EnableCookieAuth = false;
+                options.UseDotnetKeystore = false;
+                options.EnableJwtHeaderAuth = false;
+                options.ApplicationName = applicationName;
+            });
+            serviceCollection.AddScoped<IPermissionApplicationNameProvider>((services) =>
+                new DummyPermissionApplicationNameProvider(overridenApplicationName));
+
+            var serviceProvider = serviceCollection.BuildServiceProvider().CreateScope().ServiceProvider;
+            var appNameProvider = serviceProvider.GetRequiredService<IPermissionApplicationNameProvider>();
+            
+            Assert.Equal(overridenApplicationName, appNameProvider.ApplicationName());
+        }
+        
+        [Fact]
+        public void ItIsPossibleToOverrideTheIPermissionApplicationNameProviderImplementationBeforeCallingAddAuth()
+        {
+            var applicationName = "ANOTHERCOOLAPP";
+            var overridenApplicationName = "OVERRIDEN";
+            
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddScoped<IPermissionApplicationNameProvider>((services) =>
+                new DummyPermissionApplicationNameProvider(overridenApplicationName));
+            serviceCollection.AddTransient<IApplicationContext>((services) => { return Mock.Of<IApplicationContext>(); });
+            serviceCollection.AddTransient<IHostingEnvironment>((services) => { return Mock.Of<IHostingEnvironment>(); });
+            serviceCollection.AddAuth(options =>
+            {
+                options.EnableCookieAuth = false;
+                options.UseDotnetKeystore = false;
+                options.EnableJwtHeaderAuth = false;
+                options.ApplicationName = applicationName;
+            });
+
+            var serviceProvider = serviceCollection.BuildServiceProvider().CreateScope().ServiceProvider;
+            var appNameProvider = serviceProvider.GetRequiredService<IPermissionApplicationNameProvider>();
+            
+            Assert.Equal(overridenApplicationName, appNameProvider.ApplicationName());
+        }
+    }
+
+    class DummyPermissionApplicationNameProvider : IPermissionApplicationNameProvider
+    {
+        private readonly string _applicationName;
+
+        public DummyPermissionApplicationNameProvider(string applicationName)
+        {
+            _applicationName = applicationName;
+        }
+        
+        public string ApplicationName()
+        {
+            return _applicationName;
+        }
+    }
+}


### PR DESCRIPTION
This pull request includes changes so that the application name used in `PermissionsClaimsTransformer` is configurable by the developers.

This is required for MultiTenant Engines that need to use different names depending on the consuming applications.

By default, the normal behaviour is to use `AuthOptions.ApplicationName` but if needed one can implement `IPermissionApplicationNameProvider` (and register it) in order to dynamically decide upon the `ApplicationName`.