### PR TITLE
Register claims transformer scoped

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Auth Toolbox
 
+## 3.2.2
+- Fixed the service registration which gave runtime exceptions due to previous change.
+
 ## 3.2.1
 - Made it possible to override the default behaviour of retrieving the ApplicationName
 

--- a/src/Digipolis.Auth/Digipolis.Auth.csproj
+++ b/src/Digipolis.Auth/Digipolis.Auth.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>3.2.1</VersionPrefix>
+    <VersionPrefix>3.2.2</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Digipolis.Auth</AssemblyName>
     <PackageId>Digipolis.Auth</PackageId>

--- a/src/Digipolis.Auth/Startup/ServiceCollectionExtensions.cs
+++ b/src/Digipolis.Auth/Startup/ServiceCollectionExtensions.cs
@@ -168,7 +168,7 @@ namespace Digipolis.Auth
             services.AddSingleton<IAuthorizationHandler, ConventionBasedAuthorizationHandler>();
             services.AddSingleton<IAuthorizationHandler, CustomBasedAuthorizationHandler>();
             services.AddSingleton<IRequiredPermissionsResolver, RequiredPermissionsResolver>();
-            services.AddSingleton<PermissionsClaimsTransformer>();
+            services.AddScoped<PermissionsClaimsTransformer>();
             services.AddSingleton<IJwtSigningKeyResolver, JwtSigningKeyResolver>();
             services.AddSingleton<ISecurityTokenValidator, JwtSecurityTokenHandler>();
             services.AddSingleton<ITokenRefreshAgent, TokenRefreshAgent>();

--- a/src/Digipolis.Auth/Startup/ServiceCollectionExtensions.cs
+++ b/src/Digipolis.Auth/Startup/ServiceCollectionExtensions.cs
@@ -176,7 +176,7 @@ namespace Digipolis.Auth
             services.AddSingleton<ITokenValidationParametersFactory, TokenValidationParametersFactory>();
             services.AddSingleton<JwtBearerOptionsFactory>();
             services.AddSingleton<CookieOptionsFactory>();
-            services.AddSingleton<IClaimsTransformation, PermissionsClaimsTransformer>();
+            services.AddScoped<IClaimsTransformation, PermissionsClaimsTransformer>();
 
             services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.TryAddSingleton<HttpMessageHandler, HttpClientHandler>();

--- a/test/Digipolis.Auth.UnitTests/Startup/AddAuthBaseTests.cs
+++ b/test/Digipolis.Auth.UnitTests/Startup/AddAuthBaseTests.cs
@@ -95,7 +95,7 @@ namespace Digipolis.Auth.UnitTests.Startup
         }
 
         [Fact]
-        public void PermissionsClaimsTransformerIsRegisteredAsSingleton()
+        public void PermissionsClaimsTransformerIsRegisteredAsScoped()
         {
             var services = new ServiceCollection();
 
@@ -106,7 +106,7 @@ namespace Digipolis.Auth.UnitTests.Startup
                                         .ToArray();
 
             Assert.Equal(1, registrations.Count());
-            Assert.Equal(ServiceLifetime.Singleton, registrations[0].Lifetime);
+            Assert.Equal(ServiceLifetime.Scoped, registrations[0].Lifetime);
         }
 
         [Fact]


### PR DESCRIPTION
PermissionsClaimsTransformer should be registered as scoped (in stead of Singleton) otherwise it cannot consume the new `IPermissionApplicationNameProvider`