### PR TITLE
in order to be able to use the claims of the current user/principal,

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Auth Toolbox
 
+## 3.2.3
+- added the current principal to the `IIPermissionApplicationNameProvider.ApplicationName(...)` method, so one can use the claims of the current user in the logic.
+
 ## 3.2.2
 - Fixed the service registration which gave runtime exceptions due to previous change.
 

--- a/src/Digipolis.Auth/Digipolis.Auth.csproj
+++ b/src/Digipolis.Auth/Digipolis.Auth.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>3.2.2</VersionPrefix>
+    <VersionPrefix>3.2.3</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Digipolis.Auth</AssemblyName>
     <PackageId>Digipolis.Auth</PackageId>

--- a/src/Digipolis.Auth/PDP/DefaultPermissionApplicationNameProvider.cs
+++ b/src/Digipolis.Auth/PDP/DefaultPermissionApplicationNameProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Security.Claims;
 using Digipolis.Auth.Options;
 using Microsoft.Extensions.Options;
 
@@ -14,7 +15,7 @@ namespace Digipolis.Auth.PDP
             _authOptions = authOptions.Value;
         }
         
-        public string ApplicationName()
+        public string ApplicationName(ClaimsPrincipal principal)
         {
             return _authOptions.ApplicationName;
         }

--- a/src/Digipolis.Auth/PDP/IPermissionApplicationNameProvider.cs
+++ b/src/Digipolis.Auth/PDP/IPermissionApplicationNameProvider.cs
@@ -1,7 +1,9 @@
-﻿namespace Digipolis.Auth.PDP
+﻿using System.Security.Claims;
+
+namespace Digipolis.Auth.PDP
 {
     public interface IPermissionApplicationNameProvider
     {
-        string ApplicationName();
+        string ApplicationName(ClaimsPrincipal principal);
     }
 }

--- a/src/Digipolis.Auth/PDP/PermissionsClaimsTransformer.cs
+++ b/src/Digipolis.Auth/PDP/PermissionsClaimsTransformer.cs
@@ -27,7 +27,7 @@ namespace Digipolis.Auth.PDP
 
             var userId = principal.Identity.Name;
 
-            var pdpResponse = await _pdpProvider.GetPermissionsAsync(userId, _permissionApplicationNameProvider.ApplicationName());
+            var pdpResponse = await _pdpProvider.GetPermissionsAsync(userId, _permissionApplicationNameProvider.ApplicationName(principal));
 
             pdpResponse?.permissions?.ToList().ForEach(permission =>
             {


### PR DESCRIPTION
this must be passed as an parameter to the
`IPermissionApplicationNameProvider.ApplicationName()` method.

The `HttpContext.User`is not yet set at that point.